### PR TITLE
Minor fixes

### DIFF
--- a/applications/training-app/manifest.yml
+++ b/applications/training-app/manifest.yml
@@ -5,3 +5,5 @@ applications:
   memory: 64M
   buildpacks:
   - go_buildpack
+  env:
+    GOPACKAGENAME: github.com/rscale-training/training-app

--- a/site/content/application-basics/manifests.md
+++ b/site/content/application-basics/manifests.md
@@ -62,16 +62,18 @@ This reiterates the point made earlier in this section; passing parameters to th
 
 Manifests support the parameterization of values. For example, you likely want to use a different route for the development version of your app than for the production version. You could parameterize the `route` value and have it set on `push`. This allows you to use the same manifest for dev and production. 
 
-Variables are declared inside double parenthesis: i.e. `((my-variable))`. To demonstrate, let's parameterize the number of instances in our manifest by editing the file:
+Variables are declared inside double parenthesis: i.e. `((my-variable))`. To demonstrate, let's parameterize the number of instances in our manifest by editing the `static-app_manifest.yml` file:
 
 ```
 ---
 applications:
-- name: training-app
-  instances: ((instances))
-  memory: 64M
-  buildpacks:
-  - go_buildpack
+- name: static-app
+  ...
+  processes:
+  - type: web
+    instances: ((instances))
+    memory: 32M
+    ...
 ```
 
 We can then push with:

--- a/site/content/introduction/course-overview.md
+++ b/site/content/introduction/course-overview.md
@@ -33,7 +33,7 @@ We also use code blocks to show representative output from running commands. For
 /Users/steve/workspace
 ```
 
-**Variables**: In the instructions, we place variables inside of less than < and greater than > keys. You should supply your specific values in place of these blocks. For example, if you see <USERNAME> in a code block, you should replace it with your username.
+**Variables**: In the instructions, we place variables inside of less than < and greater than > keys. You should supply your specific values in place of these blocks. For example, if you see `<USERNAME>` in a code block, you should replace it with your username.
 
 ## Videos
 


### PR DESCRIPTION
**Ensure `<USERNAME>` renders**

In the [Introduction - Course Overview](https://tutorials.cloudfoundry.org/cf4devs/introduction/course-overview/) topic, ensure `<USERNAME>` renders. The < and > in this example need to be escaped or expressed as inline code, as the rendering from Markdown to HTML means it is currently getting lost:

_"For example, if you see in a code block, you should replace it with your username."_

I went for inline code to be consistent with the rest ofthe code and command sample examples.

**Use `static-app` in the [Application Basics - Manifests](https://tutorials.cloudfoundry.org/cf4devs/application-basics/manifests/) topic**

At the point of the "Variables in Manifest" section, we're still working with `static-app` and its generated manifest; the training-app hasn't yet been introduced or used at this point.

**Add `GOPACKAGENAME` env var to `training-app`'s manifest**

In the "Adding Environment Variables to the Manifest" section of the [Application Basics - Environment Variables](https://tutorials.cloudfoundry.org/cf4devs/application-basics/environment-variables/) topic, the text suggests that the app's manifest already has one environment variable set called `GOPACKAGENAME`, but it's not there. I did find an example in the `ci/` part of this repo, and used that as the reference.

(Great course, btw!)
